### PR TITLE
add _doc member to Document interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -426,6 +426,8 @@ export interface Document {
   id?: string | number;
   _id: Types.ObjectId;
 
+  _doc?: Document;
+
   equals(doc: Document): boolean;
   get(path: string, type?: new (...args: any[]) => any): any;
   inspect(options?: Object): string;


### PR DESCRIPTION
Added `_doc` member to Document interface, as the `result` of some `collection.find().limit(a).offset(b).exec((err: any, result?: T[]) => { ...` encapsulates the actual document in `_doc` for some reason.

Pls. also update https://github.com/typings/registry/blob/master/npm/mongoose.json to ensure new typings will be usable to users of [Typings](https://github.com/typings/typings).
