### PR TITLE
Fixed return type of Document.save

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -534,7 +534,7 @@ export interface Document {
   populate<T>(opt: PopulateOption, callback?: (err: any, res: T) => void): Document;
   populated(path: string): any;
   remove<T>(callback?: (err: any) => void): Query<T>;
-  save<T>(callback?: (err: any, res: T) => void): Promise<void>;
+  save<T>(callback?: (err: any, res: T) => void): Promise<T>;
   set(path: string, val: any, type?: new (...args: any[]) => any, options?: Object): void;
   set(path: string, val: any, options?: Object): void;
   set(value: Object): void;


### PR DESCRIPTION
fixed the return type of Document.save as discussed at issue #1
