### PR TITLE
add hook functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -241,8 +241,14 @@ export class Schema {
   path(path: string, constructor: any): Schema;
   pathType(path: string): string;
   plugin(plugin: (schema: Schema, options?: Object) => void, options?: Object): Schema;
-  post(method: string, fn: Function): Schema;
-  pre(method: string, callback: Function): Schema;
+  pre(method: string, fn: HookSyncCallback): Schema;
+  pre(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
+  pre(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
+  pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
+  post(method: string, fn: HookSyncCallback): Schema;
+  post(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
+  post(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
+  post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
   requiredPaths(): string[];
   set(key: string, value: any): void;
   static(name: string, fn: Function): Schema;
@@ -251,6 +257,30 @@ export class Schema {
 
   toJSON(): Object;
 }
+
+// hook functions: https://github.com/vkarpov15/hooks-fixed
+export interface HookSyncCallback {
+    (next: HookNextFunction, ...hookArgs:any[]): any;
+}
+
+export interface HookAsyncCallback {
+    (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
+}
+
+export interface HookErrorCallback {
+    (error: Error): any;
+}
+
+export interface HookNextFunction {
+    (...hookArgs:any[]): any;
+    (error: Error): any;
+}
+
+export interface HookDoneFunction {
+    (...hookArgs:any[]): any;
+    (error: Error): any;
+}
+
 export interface SchemaOption {
   autoIndex?: boolean;
   bufferCommands?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -260,25 +260,25 @@ export class Schema {
 
 // hook functions: https://github.com/vkarpov15/hooks-fixed
 export interface HookSyncCallback {
-    (next: HookNextFunction, ...hookArgs:any[]): any;
+  (next: HookNextFunction, ...hookArgs:any[]): any;
 }
 
 export interface HookAsyncCallback {
-    (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
+  (next: HookNextFunction, done: HookDoneFunction, ...hookArgs:any[]): any;
 }
 
 export interface HookErrorCallback {
-    (error: Error): any;
+  (error: Error): any;
 }
 
 export interface HookNextFunction {
-    (...hookArgs:any[]): any;
-    (error: Error): any;
+  (error: Error): any;
+  (...hookArgs:any[]): any;
 }
 
 export interface HookDoneFunction {
-    (...hookArgs:any[]): any;
-    (error: Error): any;
+  (error: Error): any;
+  (...hookArgs:any[]): any;
 }
 
 export interface SchemaOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -228,6 +228,10 @@ export class Schema {
     OId: Types.ObjectId;
     Mixed: any;
   };
+
+  methods: any;
+  statics: any;
+
   constructor(schema?: Object, options?: Object);
 
   add(obj: Object, prefix?: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -245,14 +245,10 @@ export class Schema {
   path(path: string, constructor: any): Schema;
   pathType(path: string): string;
   plugin(plugin: (schema: Schema, options?: Object) => void, options?: Object): Schema;
-  pre(method: string, fn: HookSyncCallback): Schema;
-  pre(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
-  pre(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
-  pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
-  post(method: string, fn: HookSyncCallback): Schema;
-  post(method: string, fn: HookSyncCallback, errorCb: HookErrorCallback): Schema;
-  post(method: string, isAsync: boolean, fn: HookAsyncCallback): Schema;
-  post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb: HookErrorCallback): Schema;
+  pre(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
+  pre(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
+  post(method: string, fn: HookSyncCallback, errorCb?: HookErrorCallback): Schema;
+  post(method: string, isAsync: boolean, fn: HookAsyncCallback, errorCb?: HookErrorCallback): Schema;
   requiredPaths(): string[];
   set(key: string, value: any): void;
   static(name: string, fn: Function): Schema;


### PR DESCRIPTION
1. Add details on `pre` and `post` on Schema
   Mongoose use `hooks-fixed` package to add hook methods, and should be added some detailed callback information.
   See https://github.com/vkarpov15/hooks-fixed
2. Add `static` and `methods` on Schema
   See http://mongoosejs.com/docs/2.7.x/docs/methods-statics.html
